### PR TITLE
A quick fix on spatial_mapping_dict_int inconsistance

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="1b4fd860-b9e8-491d-8907-63be57d4edbf" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/zigzag/classes/stages/SaveStage.py" beforeDir="false" afterPath="$PROJECT_DIR$/zigzag/classes/stages/SaveStage.py" afterDir="false" />
-    </list>
+    <list default="true" id="1b4fd860-b9e8-491d-8907-63be57d4edbf" name="Changes" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -23,13 +21,13 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/users/micas/jsun/sunjc/codes/branch_for_updating_zigzag_imc/zigzag-imc_fork&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "last_opened_file_path": "/users/micas/jsun/sunjc/codes/branch_for_updating_base_zigzag/base_zigzag_fork"
   }
-}</component>
+}]]></component>
   <component name="RunManager" selected="Python.debug">
     <configuration name="api" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="zigzag-imc_fork" />

--- a/zigzag/classes/opt/spatial/generator.py
+++ b/zigzag/classes/opt/spatial/generator.py
@@ -234,7 +234,10 @@ class UserSpatialMappingGenerator:
                     # 2 means: only check the top 2 spatial mapping with the highest hardware utilization
                     # Modify "2" to other numbers if you want to check on more spatial mappings.
                     break
-                new_combination, left_layer_dim_size = self.shrink_combination_when_a_layer_dim_is_mapped_on_multiple_oa_dims(
+                (
+                    new_combination,
+                    left_layer_dim_size,
+                ) = self.shrink_combination_when_a_layer_dim_is_mapped_on_multiple_oa_dims(
                     combination=combination,
                     layer=self.layer,
                 )
@@ -275,12 +278,20 @@ class UserSpatialMappingGenerator:
             for layer_dim, layer_dim_size in left_layer_dim_size.items():
                 if layer_dim_size < 1:
                     scaled_success = False
-                    for oa_index in range(len(new_combination_next)-1, -1, -1):  # reverse order on oa dims
-                        (mapped_layer_dim, mapped_layer_dim_size) = new_combination_next[oa_index]
+                    for oa_index in range(
+                        len(new_combination_next) - 1, -1, -1
+                    ):  # reverse order on oa dims
+                        (
+                            mapped_layer_dim,
+                            mapped_layer_dim_size,
+                        ) = new_combination_next[oa_index]
                         if mapped_layer_dim_size > 1:
                             # shrink the mapped layer dim size
                             mapped_layer_dim_size -= 1
-                            new_combination_next[oa_index] = (mapped_layer_dim, mapped_layer_dim_size)
+                            new_combination_next[oa_index] = (
+                                mapped_layer_dim,
+                                mapped_layer_dim_size,
+                            )
                             scaled_success = True
                             break
                         else:
@@ -288,16 +299,20 @@ class UserSpatialMappingGenerator:
                             pass
                     # assert: if not scaled_success,
                     # it means the sm loop cannot pass the check, even though all mapped size on this layer dim is 1
-                    assert scaled_success, \
-                        f"The spatial loop cannot meet the current hardware dimension after scaling, " \
+                    assert scaled_success, (
+                        f"The spatial loop cannot meet the current hardware dimension after scaling, "
                         f"Current spatial loop: {new_combination}"
+                    )
             new_combination_next = tuple(new_combination_next)
             # Next we will judge if new_combination_next is a legal loop
             # If it is, then we will keep the current combination, rather than new_combination_next,
             # the reason is: new_combination can cover the entire layer dim, but new_combination_next is smaller than
             # the layer dim, therefore the actual sm loop for the layer dim is a decimal number.
             # In that case, we will ceil it up to mimic the real case on hardware.
-            legal_spatial_loop, left_layer_dim_size_next = self.check_spatial_loop_legality(
+            (
+                legal_spatial_loop,
+                left_layer_dim_size_next,
+            ) = self.check_spatial_loop_legality(
                 combination=new_combination_next, layer=layer
             )
             if not legal_spatial_loop:


### PR DESCRIPTION
Fix the inconsistency in the `spatial_mapping_dict_int `within the cost model when spatial mapping is user-provided and is bigger than the layer size. Now, the spatial loop dimension's size will be upper-bounded to the layer dimension size, even if it is user-provided.